### PR TITLE
Add simple plugin for using TeamCity common-api

### DIFF
--- a/samples/multi-project-plugin/common/build.gradle
+++ b/samples/multi-project-plugin/common/build.gradle
@@ -1,2 +1,4 @@
 
 apply plugin: 'java'
+
+apply plugin: 'com.github.rodm.teamcity-common'

--- a/samples/multi-project-plugin/common/src/main/java/example/common/ExampleBuildFeature.java
+++ b/samples/multi-project-plugin/common/src/main/java/example/common/ExampleBuildFeature.java
@@ -1,7 +1,14 @@
 
 package example.common;
 
+import jetbrains.buildServer.util.StringUtil;
+
 public class ExampleBuildFeature {
 
     public static final String BUILD_FEATURE_NAME = "example";
+
+    {
+        // Just simple usage of TeamCity Common API (shared between server and agent)
+        assert StringUtil.isTrue("true");
+    }
 }

--- a/src/main/groovy/com/github/rodm/teamcity/TeamCityCommonPlugin.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/TeamCityCommonPlugin.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Vladislav Rassokhin from JetBrains
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.rodm.teamcity
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+
+class TeamCityCommonPlugin extends TeamCityPlugin {
+
+    @Override
+    void configureTasks(Project project, TeamCityPluginExtension extension) {
+        project.plugins.withType(JavaPlugin) {
+            project.afterEvaluate {
+                project.dependencies {
+                    provided "org.jetbrains.teamcity:common-api:${extension.version}"
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/com.github.rodm.teamcity-common.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.github.rodm.teamcity-common.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2016 Vladislav Rassokhin from JetBrains
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+implementation-class=com.github.rodm.teamcity.TeamCityCommonPlugin


### PR DESCRIPTION
It's useful for common modules shared between agent and server parts of plugin.
New plugin named 'com.github.rodm.teamcity-common'.
It just adds 'provided' configuration and 'org.jetbrains.teamcity:common-api:$version' dependency

That approach are quite simpler than adding [such code into build.gradle of common module](https://github.com/VladRassokhin/CMake-runner-plugin/blob/8f3bc10c8bc054f4902a847224551f92841715c8/cmake-runner-common/build.gradle#L19).