### PR TITLE
Added support for non-numeric TeamCity versions (such as SNAPSHOT)

### DIFF
--- a/src/functional/groovy/com/github/rodm/teamcity/ServerPluginFunctionalTest.groovy
+++ b/src/functional/groovy/com/github/rodm/teamcity/ServerPluginFunctionalTest.groovy
@@ -447,13 +447,22 @@ class ServerPluginFunctionalTest {
         assertFalse('Plugin2 archive not undeployed', plugin2File.exists())
     }
 
+    /**
+     * As we are not assembling actual project and SNAPSHOT libraries are not in any
+     * maven repository, we exclude dependencies from build script
+     */
     @Test
     void 'generate server plugin descriptor for SNAPSHOT TeamCity'() {
         buildFile << """
             plugins {
                 id 'java'
                 id 'com.github.rodm.teamcity-server'
-            }
+            }                                     
+            configurations.all {
+                dependencies {                            
+                    exclude group: 'org.jetbrains.teamcity', module: 'server-api'            
+                }            
+            }                                  
             teamcity {
                 version = 'SNAPSHOT'
                 server {

--- a/src/functional/groovy/com/github/rodm/teamcity/ServerPluginFunctionalTest.groovy
+++ b/src/functional/groovy/com/github/rodm/teamcity/ServerPluginFunctionalTest.groovy
@@ -456,13 +456,15 @@ class ServerPluginFunctionalTest {
             }
             teamcity {
                 version = 'SNAPSHOT'
-                descriptor {
-                    name = 'test-plugin'
-                    displayName = 'Some test plugin'
-                    version = '1.0-SNAPSHOT'
-                    vendorName = 'ACME Corp'
-                    vendorUrl = 'http://www.acme.com/'                    
-                    useSeparateClassloader = true
+                server {
+                    descriptor {
+                        name = 'test-plugin'
+                        displayName = 'Some test plugin'
+                        version = '1.0-SNAPSHOT'
+                        vendorName = 'ACME Corp'
+                        vendorUrl = 'http://www.acme.com/'                    
+                        useSeparateClassloader = true
+                    }
                 }
             }                   
             """

--- a/src/functional/groovy/com/github/rodm/teamcity/ServerPluginFunctionalTest.groovy
+++ b/src/functional/groovy/com/github/rodm/teamcity/ServerPluginFunctionalTest.groovy
@@ -36,7 +36,7 @@ import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 
-public class ServerPluginFunctionalTest {
+class ServerPluginFunctionalTest {
 
     static final String BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR = """
         plugins {
@@ -81,7 +81,7 @@ public class ServerPluginFunctionalTest {
     private File buildFile
 
     @Before
-    public void setup() throws IOException {
+    void setup() throws IOException {
         buildFile = testProjectDir.newFile("build.gradle")
     }
 
@@ -94,7 +94,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void serverPluginBuildAndPackage() {
+    void serverPluginBuildAndPackage() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         File settingsFile = testProjectDir.newFile('settings.gradle')
@@ -115,10 +115,10 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void serverPluginWithDescriptorFile() {
+    void serverPluginWithDescriptorFile() {
         buildFile << BUILD_SCRIPT_WITH_FILE_DESCRIPTOR
 
-        File descriptorFile = testProjectDir.newFile("teamcity-plugin.xml");
+        File descriptorFile = testProjectDir.newFile("teamcity-plugin.xml")
         descriptorFile << """<?xml version="1.0" encoding="UTF-8"?>
             <teamcity-plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                              xsi:noNamespaceSchemaLocation="urn:schemas-jetbrains-com:teamcity-plugin-v1-xml">
@@ -139,7 +139,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void serverPluginNoWarningsWithDefinitionFile() {
+    void serverPluginNoWarningsWithDefinitionFile() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         File metaInfDir = testProjectDir.newFolder('src', 'main', 'resources', 'META-INF')
@@ -152,7 +152,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void serverPluginWarnsAboutMissingDefinitionFile() {
+    void serverPluginWarnsAboutMissingDefinitionFile() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         BuildResult result = executeBuild()
@@ -161,7 +161,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void noWarningWithValidDefinitionFile() {
+    void noWarningWithValidDefinitionFile() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         File exampleJavaDir = testProjectDir.newFolder('src', 'main', 'java', 'example')
@@ -183,7 +183,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void warningAboutMissingClass() {
+    void warningAboutMissingClass() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         File metaInfDir = testProjectDir.newFolder('src', 'main', 'resources', 'META-INF')
@@ -198,7 +198,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void supportOlderPluginDefinitionFile() {
+    void supportOlderPluginDefinitionFile() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         File exampleJavaDir = testProjectDir.newFolder('src', 'main', 'java', 'example')
@@ -225,7 +225,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void serverPluginFailsWithMissingDescriptorFile() {
+    void serverPluginFailsWithMissingDescriptorFile() {
         buildFile << BUILD_SCRIPT_WITH_FILE_DESCRIPTOR
 
         BuildResult result = GradleRunner.create()
@@ -239,10 +239,10 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void invalidServerPluginDescriptor() {
+    void invalidServerPluginDescriptor() {
         buildFile << BUILD_SCRIPT_WITH_FILE_DESCRIPTOR
 
-        File descriptorFile = testProjectDir.newFile("teamcity-plugin.xml");
+        File descriptorFile = testProjectDir.newFile("teamcity-plugin.xml")
         descriptorFile << """<?xml version="1.0" encoding="UTF-8"?>
             <teamcity-plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                              xsi:noNamespaceSchemaLocation="urn:schemas-jetbrains-com:teamcity-plugin-v1-xml">
@@ -258,14 +258,14 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void simulateBuildingPluginInTeamCity() {
+    void simulateBuildingPluginInTeamCity() {
         buildFile << BUILD_SCRIPT_WITH_INLINE_DESCRIPTOR
 
         // Provides similar functionality to the init.gradle script used by the TeamCity Gradle Runner plugin
         File initFile = testProjectDir.newFile('init.gradle')
         initFile << """
             public class DummyTeamcityPropertiesListener implements ProjectEvaluationListener {
-                public void beforeEvaluate(Project project) {
+                void beforeEvaluate(Project project) {
                     def props = [:]
                     if (project.hasProperty("ext")) {
                         project.ext.teamcity = props
@@ -273,7 +273,7 @@ public class ServerPluginFunctionalTest {
                         project.setProperty("teamcity", props)
                     }
                 }
-                public void afterEvaluate(Project project, ProjectState projectState) {
+                void afterEvaluate(Project project, ProjectState projectState) {
                 }
             }
             gradle.addListener(new DummyTeamcityPropertiesListener())
@@ -285,7 +285,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void startServerAfterDeployingPlugin() {
+    void startServerAfterDeployingPlugin() {
         File homeDir = createFakeTeamCityInstall('teamcity', '9.1.6')
         File dataDir = testProjectDir.newFolder('data')
 
@@ -325,7 +325,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void startNamedEnvironmentServer() {
+    void startNamedEnvironmentServer() {
         createFakeTeamCityInstall('teamcity', '9.1.6')
 
         buildFile << """
@@ -369,7 +369,7 @@ public class ServerPluginFunctionalTest {
     public final TemporaryFolder serversDir = new TemporaryFolder()
 
     @Test
-    public void startNamedEnvironmentServerInAlternativeDirectory() {
+    void startNamedEnvironmentServerInAlternativeDirectory() {
         createFakeTeamCityInstall(serversDir, 'teamcity', '9.1.6')
 
         buildFile << """
@@ -411,7 +411,7 @@ public class ServerPluginFunctionalTest {
     }
 
     @Test
-    public void 'deploy and undeploy multiple plugins to and from an environment'() {
+    void 'deploy and undeploy multiple plugins to and from an environment'() {
         buildFile << """
             plugins {
                 id 'java'
@@ -447,11 +447,47 @@ public class ServerPluginFunctionalTest {
         assertFalse('Plugin2 archive not undeployed', plugin2File.exists())
     }
 
+    @Test
+    void 'generate server plugin descriptor for SNAPSHOT TeamCity'() {
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'com.github.rodm.teamcity-server'
+            }
+            teamcity {
+                version = 'SNAPSHOT'
+                descriptor {
+                    name = 'test-plugin'
+                    displayName = 'Some test plugin'
+                    version = '1.0-SNAPSHOT'
+                    vendorName = 'ACME Corp'
+                    vendorUrl = 'http://www.acme.com/'                    
+                    useSeparateClassloader = true
+                }
+            }                   
+            """
+        File settingsFile = testProjectDir.newFile('settings.gradle')
+        settingsFile << """
+            rootProject.name = 'test-plugin'
+        """
+
+        BuildResult result = executeBuild()
+
+        assertEquals(result.task(":generateServerDescriptor").getOutcome(), SUCCESS)
+        assertEquals(result.task(":processServerDescriptor").getOutcome(), SKIPPED)
+        assertEquals(result.task(":serverPlugin").getOutcome(), SUCCESS)
+
+        ZipFile pluginFile = new ZipFile(new File(testProjectDir.root, 'build/distributions/test-plugin.zip'))
+        List<String> entries = pluginFile.entries().collect { it.name }
+        assertThat(entries, hasItem('teamcity-plugin.xml'))
+        assertThat(entries, hasItem('server/test-plugin.jar'))
+    }
+
     private File createFakeTeamCityInstall(String baseDir, String version) {
         createFakeTeamCityInstall(testProjectDir, baseDir, version)
     }
 
-    private File createFakeTeamCityInstall(TemporaryFolder folder, String baseDir, String version) {
+    private static File createFakeTeamCityInstall(TemporaryFolder folder, String baseDir, String version) {
         File homeDir = folder.newFolder(baseDir, "TeamCity-${version}")
         File binDir = folder.newFolder(baseDir, "TeamCity-${version}", 'bin')
 
@@ -470,7 +506,7 @@ public class ServerPluginFunctionalTest {
         return homeDir
     }
 
-    private String windowsCompatiblePath(File path) {
+    private static String windowsCompatiblePath(File path) {
         path.canonicalPath.replace('\\', '\\\\')
     }
 }

--- a/src/main/groovy/com/github/rodm/teamcity/ServerPluginDescriptorGenerator.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/ServerPluginDescriptorGenerator.groovy
@@ -31,7 +31,7 @@ class ServerPluginDescriptorGenerator {
         this.defaults = defaults
     }
 
-    public void writeTo(Writer writer) {
+    void writeTo(Writer writer) {
         Node root = new Node(null, "teamcity-plugin", [
                 "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
                 "xsi:noNamespaceSchemaLocation": "urn:schemas-jetbrains-com:teamcity-plugin-v1-xml"
@@ -95,7 +95,8 @@ class ServerPluginDescriptorGenerator {
     }
 
     private void buildDependenciesNode(Node root) {
-        if (getMajorVersion(version) >= 9) {
+        def version = getMajorVersion(version)
+        if (version == null || version >= 9) {
             if (descriptor.getDependencies().hasDependencies()) {
                 Node dependencies = root.appendNode('dependencies')
                 descriptor.getDependencies().plugins.each { name ->
@@ -108,8 +109,8 @@ class ServerPluginDescriptorGenerator {
         }
     }
 
-    private static int getMajorVersion(String version) {
-        String[] parts = version.split('\\.')
-        return parts[0] as int
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    private static Integer getMajorVersion(String version) {
+        return (version ==~ /(\d+)\..*/) ? (version =~ /(\d+)\..*/)[0][1] as int : null
     }
 }

--- a/src/main/groovy/com/github/rodm/teamcity/TeamCityPluginExtension.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/TeamCityPluginExtension.groovy
@@ -40,9 +40,9 @@ class TeamCityPluginExtension {
         this.server = new ServerPluginConfiguration(project, environments)
     }
 
-    int getMajorVersion() {
-        String[] parts = version.split('\\.')
-        return parts[0] as int
+    @SuppressWarnings("GroovyAssignabilityCheck")
+    Integer getMajorVersion() {
+        return (version ==~ /(\d+)\..*/) ? (version =~ /(\d+)\..*/)[0][1] as int : null
     }
 
     def getAgent() {

--- a/src/main/groovy/com/github/rodm/teamcity/tasks/GenerateAgentPluginDescriptor.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/tasks/GenerateAgentPluginDescriptor.groovy
@@ -49,7 +49,9 @@ class GenerateAgentPluginDescriptor extends DefaultTask {
         if (descriptor == null) {
             descriptor = new AgentPluginDescriptor()
         }
-        if (extension.getMajorVersion() < 9 && descriptor.dependencies.hasDependencies()) {
+        
+        def version = extension.getMajorVersion()
+        if (version != null && version < 9 && descriptor.dependencies.hasDependencies()) {
             project.logger.warn("${path}: Plugin descriptor does not support dependencies for version ${extension.version}")
         }
         AgentPluginDescriptorGenerator generator = new AgentPluginDescriptorGenerator(descriptor)

--- a/src/main/groovy/com/github/rodm/teamcity/tasks/GenerateServerPluginDescriptor.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/tasks/GenerateServerPluginDescriptor.groovy
@@ -49,7 +49,9 @@ class GenerateServerPluginDescriptor extends DefaultTask {
         if (descriptor == null) {
             descriptor = new ServerPluginDescriptor()
         }
-        if (extension.getMajorVersion() < 9 && descriptor.dependencies.hasDependencies()) {
+
+        def version = extension.getMajorVersion()
+        if (version != null && version < 9 && descriptor.dependencies.hasDependencies()) {
             project.logger.warn("${path}: Plugin descriptor does not support dependencies for version ${extension.version}")
         }
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor, extension.getVersion(), defaults())

--- a/src/test/groovy/com/github/rodm/teamcity/ServerDescriptorGeneratorTest.groovy
+++ b/src/test/groovy/com/github/rodm/teamcity/ServerDescriptorGeneratorTest.groovy
@@ -25,14 +25,14 @@ import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.not
 
-public class ServerDescriptorGeneratorTest {
+class ServerDescriptorGeneratorTest {
 
-    private Project project;
+    private Project project
 
     private TeamCityPluginExtension extension
 
     @Before
-    public void setup() {
+    void setup() {
         project = ProjectBuilder.builder()
                 .withName('test-plugin')
                 .build()
@@ -41,18 +41,18 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writesTeamCityPluginRootNode() {
-        StringWriter writer = new StringWriter();
+    void writesTeamCityPluginRootNode() {
+        StringWriter writer = new StringWriter()
         ServerPluginDescriptor descriptor = new ServerPluginDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
 
-        generator.writeTo(writer);
+        generator.writeTo(writer)
 
         assertThat(writer.toString(), hasXPath("/teamcity-plugin"))
     }
 
     @Test
-    public void writesRequiredInfoProperties() {
+    void writesRequiredInfoProperties() {
         project.teamcity {
             server {
                 descriptor {
@@ -65,9 +65,9 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
-        generator.writeTo(writer);
+        generator.writeTo(writer)
 
         assertThat(writer.toString(), hasXPath('//info/name', equalTo('plugin name')))
         assertThat(writer.toString(), hasXPath('//info/display-name', equalTo('display name')))
@@ -76,10 +76,10 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writesRequiredInfoPropertiesWhenNotSet() {
+    void writesRequiredInfoPropertiesWhenNotSet() {
         ServerPluginDescriptor descriptor = new ServerPluginDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -90,14 +90,14 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writesRequiredInfoPropertiesUsingDefaults() {
+    void writesRequiredInfoPropertiesUsingDefaults() {
         def defaults = [:]
         defaults << ['name': 'test-plugin name']
         defaults << ['displayName': 'test-plugin display name']
         defaults << ['version': '1.2.3']
         ServerPluginDescriptor descriptor = new ServerPluginDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor, "9.0", defaults)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -107,7 +107,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writesOptionalInfoProperties() {
+    void writesOptionalInfoProperties() {
         project.teamcity {
             server {
                 descriptor {
@@ -121,7 +121,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -133,7 +133,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void optionalInfoPropertiesNotWrittenWhenNotSet() {
+    void optionalInfoPropertiesNotWrittenWhenNotSet() {
         project.teamcity {
             server {
                 descriptor {
@@ -142,7 +142,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -154,7 +154,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeOptionalSeparateClassloader() {
+    void writeOptionalSeparateClassloader() {
         project.teamcity {
             server {
                 descriptor {
@@ -164,7 +164,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -172,7 +172,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeOptionalSeparateClassloaderWhenFalse() {
+    void writeOptionalSeparateClassloaderWhenFalse() {
         project.teamcity {
             server {
                 descriptor {
@@ -183,7 +183,7 @@ public class ServerDescriptorGeneratorTest {
 
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -191,7 +191,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeOptionalSettingsOnlyIfSpecified() {
+    void writeOptionalSettingsOnlyIfSpecified() {
         project.teamcity {
             server {
                 descriptor {
@@ -200,7 +200,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -209,7 +209,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeParameters() {
+    void writeParameters() {
         project.teamcity {
             server {
                 descriptor {
@@ -222,7 +222,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -232,7 +232,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writePluginDependency() {
+    void writePluginDependency() {
         project.teamcity {
             server {
                 descriptor {
@@ -244,7 +244,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -252,7 +252,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeToolDependency() {
+    void writeToolDependency() {
         project.teamcity {
             server {
                 descriptor {
@@ -264,7 +264,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -272,7 +272,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeDependenciesOnlyIfSpecified() {
+    void writeDependenciesOnlyIfSpecified() {
         project.teamcity {
             server {
                 descriptor {
@@ -283,7 +283,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -291,7 +291,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeDependenciesOnlyForTeamCity9() {
+    void writeDependenciesOnlyForTeamCity9() {
         project.teamcity {
             version = '8.1'
             server {
@@ -304,7 +304,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor, extension.getVersion())
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -312,7 +312,28 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeDependenciesForTeamCity10() {
+    void writeDescriptorForNonNumericTCVersion() {
+        project.teamcity {
+            version = 'SNAPSHOT'
+            server {
+                descriptor {
+                    dependencies {
+                        plugin 'plugin-name'
+                    }
+                }
+            }
+        }
+        ServerPluginDescriptor descriptor = extension.server.getDescriptor()
+        ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor, extension.getVersion())
+        StringWriter writer = new StringWriter()
+
+        generator.writeTo(writer)
+
+        assertThat(writer.toString(), hasXPath('//dependencies'))
+    }
+
+    @Test
+    void writeDependenciesForTeamCity10() {
         project.teamcity {
             version = '10.0'
             server {
@@ -325,7 +346,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor, extension.getVersion())
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -333,7 +354,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeRequirements() {
+    void writeRequirements() {
         project.teamcity {
             server {
                 descriptor {
@@ -344,7 +365,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -353,7 +374,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeRequirementsMinimumBuildOnly() {
+    void writeRequirementsMinimumBuildOnly() {
         project.teamcity {
             server {
                 descriptor {
@@ -363,7 +384,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -372,7 +393,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeRequirementsMaximumBuildOnly() {
+    void writeRequirementsMaximumBuildOnly() {
         project.teamcity {
             server {
                 descriptor {
@@ -382,7 +403,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 
@@ -391,7 +412,7 @@ public class ServerDescriptorGeneratorTest {
     }
 
     @Test
-    public void writeRequirementsOnlyIfSpecified() {
+    void writeRequirementsOnlyIfSpecified() {
         project.teamcity {
             server {
                 descriptor {
@@ -400,7 +421,7 @@ public class ServerDescriptorGeneratorTest {
         }
         ServerPluginDescriptor descriptor = extension.server.getDescriptor()
         ServerPluginDescriptorGenerator generator = new ServerPluginDescriptorGenerator(descriptor)
-        StringWriter writer = new StringWriter();
+        StringWriter writer = new StringWriter()
 
         generator.writeTo(writer)
 


### PR DESCRIPTION
gradle-teamcity-plugin fails to generate plugin descriptors when non-numeric version (for example 'SNAPSHOT') is used due to NumberFormatException in getMajorVersion(). This forces to use external plugin descriptors and replace tokens inside existing xmls
I have added handling of such cases, tests and done some code cleanup