### PR TITLE
Move JUnit platform definition to testImplementation configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,10 @@ dependencies {
     implementation 'org.jetbrains.intellij.plugins:structure-base:3.112'
     implementation 'org.jetbrains.intellij.plugins:structure-teamcity:3.112'
     implementation 'org.jetbrains.intellij:plugin-repository-rest-client:2.0.11'
-    implementation(platform('org.junit:junit-bom:5.6.2')) {
+
+    testImplementation(platform('org.junit:junit-bom:5.6.2')) {
         because('Platform, Jupiter, and Vintage versions should match')
     }
-
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.xmlunit:xmlunit-matchers:2.7.0'


### PR DESCRIPTION
With Gradle 6.7, builds can no longer apply the `com.github.rodm:gradle-teamcity-plugin:1.3` plugin since its dependencies contain a JUnit BOM dependency with wrong dependency metadata (due to a bug in the gradle publishing plugin that will be fixed soon by the Gradle team). This wrong dependency leads to a build failure at compilation time. Moving the JUnit platform definition to `testImplementation` (which is reasonable anyway) avoids the described issue on the plugin consumer's side.

There is a [workaround](https://github.com/etiennestuder/teamcity-build-scan-plugin/blob/master/build.gradle#L3-L13) when using Gradle 6.7 with the gradle-teamcity-plugin 1.3.

//cc @ljacomet who helped getting to the bottom of the issue and the workaround