### PR TITLE
Add sign plugin task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.jetbrains.intellij.plugins:structure-base:3.112'
     implementation 'org.jetbrains.intellij.plugins:structure-teamcity:3.112'
     implementation 'org.jetbrains.intellij:plugin-repository-rest-client:2.0.11'
+    implementation 'org.jetbrains:marketplace-zip-signer:0.1.2'
 
     testImplementation(platform('org.junit:junit-bom:5.6.2')) {
         because('Platform, Jupiter, and Vintage versions should match')

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,25 @@ test {
 
 gradlePlugin {
     testSourceSets sourceSets.functionalTest, sourceSets.samples
+
+    plugins {
+        teamcityServerPlugin {
+            id = 'com.github.rodm.teamcity-server'
+            implementationClass = 'com.github.rodm.teamcity.TeamCityServerPlugin'
+        }
+        teamcityAgentPlugin {
+            id = 'com.github.rodm.teamcity-agent'
+            implementationClass = 'com.github.rodm.teamcity.TeamCityAgentPlugin'
+        }
+        teamcityCommonPlugin {
+            id = 'com.github.rodm.teamcity-common'
+            implementationClass = 'com.github.rodm.teamcity.TeamCityCommonPlugin'
+        }
+        teamcityEnvironmentsPlugin {
+            id = 'com.github.rodm.teamcity-environments'
+            implementationClass = 'com.github.rodm.teamcity.TeamCityEnvironmentsPlugin'
+        }
+    }
 }
 
 task functionalTest(type: Test) {
@@ -97,19 +116,15 @@ pluginBundle {
 
     plugins {
         teamcityServerPlugin {
-            id = 'com.github.rodm.teamcity-server'
             displayName = 'Gradle TeamCity Server plugin'
         }
         teamcityAgentPlugin {
-            id = 'com.github.rodm.teamcity-agent'
             displayName = 'Gradle TeamCity Agent plugin'
         }
         teamcityCommonPlugin {
-            id = 'com.github.rodm.teamcity-common'
             displayName = 'Gradle TeamCity Common API plugin'
         }
         teamcityEnvironmentsPlugin {
-            id = 'com.github.rodm.teamcity-environments'
             displayName = 'Gradle TeamCity Environments plugin'
         }
     }

--- a/src/main/groovy/com/github/rodm/teamcity/ServerPluginConfiguration.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/ServerPluginConfiguration.groovy
@@ -33,6 +33,7 @@ class ServerPluginConfiguration extends PluginConfiguration {
     private Project project
     private ConfigurableFileCollection web
     private PublishConfiguration publish
+    private SignConfiguration sign
 
     @Delegate
     private TeamCityEnvironments environments
@@ -89,6 +90,18 @@ class ServerPluginConfiguration extends PluginConfiguration {
 
     PublishConfiguration getPublish() {
         return publish
+    }
+
+    void sign(Action<SignConfiguration> configuration) {
+        if (!sign) {
+            sign = (this as ExtensionAware).extensions.create('sign', SignConfiguration, project)
+        }
+        configuration.execute(sign)
+    }
+
+
+    SignConfiguration getSign() {
+        return sign
     }
 
     void setDownloadsDir(String downloadsDir) {

--- a/src/main/groovy/com/github/rodm/teamcity/SignConfiguration.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/SignConfiguration.groovy
@@ -1,0 +1,46 @@
+package com.github.rodm.teamcity
+
+import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.jetbrains.zip.signer.signer.CertificateUtils
+import org.jetbrains.zip.signer.signer.PrivateKeyUtils
+
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+
+class SignConfiguration {
+    private ListProperty<X509Certificate> certificateChain
+    private Property<PrivateKey> privateKey
+    private Project project
+
+    SignConfiguration(Project project) {
+        this.project = project
+        this.certificateChain = project.objects.listProperty(X509Certificate)
+        this.privateKey = project.objects.property(PrivateKey)
+    }
+
+    ListProperty<X509Certificate> getCertificateChain() {
+        return certificateChain
+    }
+
+    void setCertificateChain(List<X509Certificate> certificateChain) {
+        this.certificateChain.set(certificateChain)
+    }
+
+    Property<PrivateKey> getPrivateKey() {
+        return privateKey
+    }
+
+    void setPrivateKey(PrivateKey privateKey) {
+        this.privateKey.set(privateKey)
+    }
+
+    List<X509Certificate> loadCertificateChain(File file) {
+        return CertificateUtils.loadCertificatesFromFile(file)
+    }
+
+    PrivateKey loadPrivateKey(File file, String password = null) {
+        return PrivateKeyUtils.loadPrivateKey(file, password?.toCharArray())
+    }
+}

--- a/src/main/groovy/com/github/rodm/teamcity/tasks/SignPluginTask.groovy
+++ b/src/main/groovy/com/github/rodm/teamcity/tasks/SignPluginTask.groovy
@@ -1,0 +1,73 @@
+package com.github.rodm.teamcity.tasks
+
+import org.apache.commons.io.FilenameUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.zip.signer.signer.PublicKeyUtils
+import org.jetbrains.zip.signer.signing.DefaultSignatureProvider
+import org.jetbrains.zip.signer.signing.ZipSigner
+
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+
+class SignPluginTask extends DefaultTask {
+    private RegularFileProperty pluginFile = project.objects.fileProperty()
+    private RegularFileProperty signedPluginFile = project.objects.fileProperty()
+    private ListProperty<X509Certificate> certificateChain = project.objects.listProperty(X509Certificate)
+    private Property<PrivateKey> privateKey = project.objects.property(PrivateKey)
+
+    /**
+     * @return the plugin file that will be signed
+     */
+    @InputFile
+    RegularFileProperty getPluginFile() {
+        return pluginFile
+    }
+
+    /**
+     * @return signed plugin file
+     */
+    @OutputFile
+    RegularFileProperty getSignedPluginFile() {
+        return signedPluginFile
+    }
+
+
+    @Input
+    ListProperty<X509Certificate> getCertificateChain() {
+        return certificateChain
+    }
+
+    @Input
+    Property<PrivateKey> getPrivateKey() {
+        return privateKey
+    }
+
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    @TaskAction
+    protected void signPlugin() {
+        def pluginFile = getPluginFile().get().asFile
+        def defaultSignedPluginName = FilenameUtils.removeExtension(pluginFile.path)
+        def signedPluginFile = getSignedPluginFile().getOrNull()?.asFile ?:
+            new File(defaultSignedPluginName + "-signed" + FilenameUtils.getExtension(pluginFile.name))
+
+        def certificateChain = getCertificateChain().get()
+        def privateKey = getPrivateKey().get()
+
+        ZipSigner.sign(
+            pluginFile,
+            signedPluginFile,
+            certificateChain,
+            new DefaultSignatureProvider(
+                PublicKeyUtils.INSTANCE.getSuggestedSignatureAlgorithm(certificateChain[0].publicKey),
+                privateKey
+            )
+        )
+    }
+}


### PR DESCRIPTION
Some time ago we have added a [signing mechanism](https://blog.jetbrains.com/platform/2020/09/plugin-signing-in-marketplace/) for JetBrains plugins. Currently, all TeamCity plugins are signed by the marketplace and we are adding signature checks to the product. 
Those changes will allow plugin developers to sign their plugins using personal certificates. It is needed to safely distribute non-marketplace plugins and later it will be used for the plugin upload. 