### PR TITLE
Upgrade workflows to `gradle-build-action@v2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,13 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Gradle version
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --version
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: -s build
-          distributions-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: false
 
   test:
     runs-on: ${{ matrix.os }}
@@ -50,20 +47,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 8
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-test-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-test-
       - name: Build with Gradle
-        run: |
-          ./gradlew -v
-          ./gradlew -s functionalTest
-          ./gradlew --stop
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: -s functionalTest
       - name: Upload reports
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
Upgrades the GitHub actions workflows to the latest v2 version (presently v2.0-beta.7).

This new action:
- has simpler configuration
- does a better job of caching the Gradle User Home state between build invocations
- automatically adds annotations with build scan URLs for all gradle invocations.

Due to the second item, I've removed the separate use of `actions/cache` for caching.
I'd be very interested to know if there is any regression in performance with this change.