### PR TITLE
Support 2023.09-12345 format revisions

### DIFF
--- a/src/main/java/com/github/rodm/teamcity/TeamCityVersion.java
+++ b/src/main/java/com/github/rodm/teamcity/TeamCityVersion.java
@@ -23,8 +23,8 @@ import java.util.regex.Pattern;
 
 public class TeamCityVersion implements Comparable<TeamCityVersion>, Serializable {
 
-    private static final Pattern RELEASE_VERSION_PATTERN = Pattern.compile("^(\\d+)(\\.\\d+){1,2}+");
-    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("^(\\d+)(\\.\\d+){1,2}+-SNAPSHOT");
+    private static final Pattern RELEASE_VERSION_PATTERN = Pattern.compile("^(\\d+)(([\\.\\-]\\d+){1,2}){1,2}");
+    private static final Pattern SNAPSHOT_VERSION_PATTERN = Pattern.compile("^(\\d+)(\\.\\d+){1,2}+-(SNAPSHOT|\\d+)");
     private static final Pattern DATA_VERSION_PATTERN = Pattern.compile("^(\\d+\\.\\d+).*");
 
     private static final String INVALID_RELEASE_MESSAGE = "'%s' is not a valid TeamCity version string (examples: '9.0', '10.0.5', '2018.1')";

--- a/src/test/groovy/com/github/rodm/teamcity/TeamCityVersionTest.groovy
+++ b/src/test/groovy/com/github/rodm/teamcity/TeamCityVersionTest.groovy
@@ -43,6 +43,8 @@ class TeamCityVersionTest {
         version('2018.2')
         version('2022.04')
         version('2023.10')
+        version('2023.10-12345')
+        version('2023.09-23456')
         version('SNAPSHOT')
     }
 
@@ -62,6 +64,7 @@ class TeamCityVersionTest {
         assertThat(version('9.0'), lessThan(version('2018.1')))
         assertThat(version('2018.1.2'), lessThan(version('2018.1.3')))
         assertThat(version('2018.1.2'), lessThan(version('SNAPSHOT')))
+        assertThat(version('2018.1-12345'), lessThan(version('2018.1-23451')))
 
         assertThat(version('9.0'), equalTo(VERSION_9_0))
         assertThat(version('2018.2'), equalTo(VERSION_2018_2))
@@ -71,6 +74,7 @@ class TeamCityVersionTest {
         assertThat(version('9.0.1'), greaterThan(version('9.0')))
         assertThat(version('10.0'), greaterThan(version('9.0')))
         assertThat(version('SNAPSHOT'), greaterThan(version('2018.1.2')))
+        assertThat(version('SNAPSHOT'), greaterThan(version('2018.1-12345')))
     }
 
     @Test
@@ -142,6 +146,8 @@ class TeamCityVersionTest {
             assertThat(version('9.0.1-SNAPSHOT'), greaterThan(version('9.0-SNAPSHOT')))
             assertThat(version('10.0-SNAPSHOT'), greaterThan(version('9.0-SNAPSHOT')))
             assertThat(version('SNAPSHOT'), greaterThan(version('2020.2-SNAPSHOT')))
+            assertThat(version('2018.1-SNAPSHOT'), lessThan(version('2018.1-23451')))
+            assertThat(version('2019.1-SNAPSHOT'), greaterThan(version('2018.1-23451')))
         }
 
         @Test


### PR DESCRIPTION
@rodm In the future we might want to follow some basic semantic version rules like by the link.
https://github.com/apache/maven/blob/master/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java

